### PR TITLE
Swapped autoprefixer-core for autoprefixer

### DIFF
--- a/lasso-autoprefixer.js
+++ b/lasso-autoprefixer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var autoprefixer = require('autoprefixer-core');
+var autoprefixer = require('autoprefixer');
 var postcss = require('postcss');
 var DEFAULT_CONFIG = {
     browsers: ['last 4 versions']

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "Merwan Rodriguez <merwan@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "autoprefixer-core": "^5.2.1",
-    "postcss": "^4.1.16"
+    "autoprefixer": "^6.3.3",
+    "postcss": "^5.0.16"
   },
   "devDependencies": {
     "mocha": "~1.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lasso-autoprefixer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Autoprefixer plugin for Lasso.js using postcss & autoprefixer-core",
   "keywords": [
     "lasso",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lasso-autoprefixer",
   "version": "1.0.4",
-  "description": "Autoprefixer plugin for Lasso.js using postcss & autoprefixer-core",
+  "description": "Autoprefixer plugin for Lasso.js using postcss & autoprefixer",
   "keywords": [
     "lasso",
     "lasso-plugin",


### PR DESCRIPTION
`autoprefixer-core` is [deprecated](https://github.com/ai/autoprefixer-core). I've gone ahead and swapped `autoprefixer-core` for `autoprefixer`. I've tested and it's working with the latest versions of `autoprefixer` and `postCSS`.

Closes #2.
#### Note

There were some [changes in Autoprefixer 6.2](https://github.com/postcss/autoprefixer/releases/tag/6.2.0) that may affect compiled CSS with the `transition-property: color, filter`. The Autoprefixer team has not found a solution for this and Autoprefixer has been programmed to show the warning and suggest for you to use multiple names only in safer `transition` instead of `transition-*`.

However, in my tests I have not seen warnings from Lasso either before or after making this update. @patrick-steele-idem should this plugin be able to output warnings to the terminal? If so, I'm not sure how to make that happen.
