### PR TITLE
remove default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ require('lasso').configure({
 
 # Plugin Configuration
 
-
-This plugin uses [Autoprefixer options](https://github.com/postcss/autoprefixer#options);
+It is recommended to use config that is [shareable between all tools] (https://github.com/postcss/autoprefixer#browsers), but config can also be passed directly if needed. See [Autoprefixer options](https://github.com/postcss/autoprefixer#options).
 
 
 ## Sample Configuration

--- a/lasso-autoprefixer.js
+++ b/lasso-autoprefixer.js
@@ -2,14 +2,8 @@
 
 var autoprefixer = require('autoprefixer');
 var postcss = require('postcss');
-var DEFAULT_CONFIG = {
-    browsers: ['last 4 versions']
-};
 
 module.exports = function(lasso, config) {
-    // use DEFAULT_CONFIG if config not present
-    config = config || DEFAULT_CONFIG;
-
     lasso.addTransform({
         contentType: 'css',
         name: module.id,


### PR DESCRIPTION
Fixes https://github.com/lasso-js/lasso-autoprefixer/issues/7

I've removed the default config so that config can be shared more naturally between all forms of tooling. This is the method recommended by `autoprefixer`.

This is technically a breaking change.