### PR TITLE
Fix link to autoprefixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 lasso-autoprefixer
 ==================
-This plugin for the [Lasso.js](https://github.com/lasso-js/lasso) will run your css through [autoprefixer](https://github.com/postcss/autoprefixer-core) allowing you to write css without having to worry about vendor prefixes.
+This plugin for the [Lasso.js](https://github.com/lasso-js/lasso) will run your css through [autoprefixer](https://github.com/postcss/autoprefixer) allowing you to write css without having to worry about vendor prefixes.
 
 # Installation
 


### PR DESCRIPTION
Small fix to update `autoprefixer` link in README.md. 
It was previously pointing to a deprecated repo.